### PR TITLE
Problem : We need to avoid cxxtools log trace definition

### DIFF
--- a/include/fty-common/log/fty_log.h
+++ b/include/fty-common/log/fty_log.h
@@ -25,6 +25,7 @@
 // Trick to avoid conflict with CXXTOOLS logger, currently the BIOS code
 // prefers OUR logger macros
 #if defined(LOG_CXXTOOLS_H) || defined(CXXTOOLS_LOG_CXXTOOLS_H)
+#undef log_trace
 #undef log_error
 #undef log_debug
 #undef log_info


### PR DESCRIPTION
Solution : add #undef log_trace if cxxtools log defined
Signed-off-by: barraudl <lilianbarraud@eaton.com>