### PR TITLE
Problem: we don't want cxxtools logger but want to be sure of the rest

### DIFF
--- a/include/fty-common/log/fty_log.h
+++ b/include/fty-common/log/fty_log.h
@@ -22,6 +22,9 @@
 #ifndef FTY_LOG_H_INCLUDED
 #define FTY_LOG_H_INCLUDED
 
+#ifdef __cplusplus
+#include <cxxtools/log.h>
+#endif
 // Trick to avoid conflict with CXXTOOLS logger, currently the BIOS code
 // prefers OUR logger macros
 #if defined(LOG_CXXTOOLS_H) || defined(CXXTOOLS_LOG_CXXTOOLS_H)


### PR DESCRIPTION
Solution :  include cxxtools/log.h in front of fty_log.h

Signed-off-by: barraudl <lilianbarraud@eaton.com>