### PR TITLE
Problem: CentOS package for fty-common does not build.

### DIFF
--- a/packaging/redhat/fty-common.spec
+++ b/packaging/redhat/fty-common.spec
@@ -105,6 +105,8 @@ This package contains development files for fty-common: provides common tools fo
 
 %build
 sh autogen.sh
+# WORKAROUND for the fact that log4cplus installs its pkgconfig here
+export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
 %{configure} --enable-drafts=%{DRAFTS} --with-libtntnet=yes
 make %{_smp_mflags}
 


### PR DESCRIPTION
Solution: Work around the fact that out distribution of log4cplus installs package config to unexpected directory.

Signed-off-by: Jana Rapava <janarapava@eaton.com>