### PR TITLE
Problem : saslauth uses an old bios service

### DIFF
--- a/src/fty-common/web/sasl.cc
+++ b/src/fty-common/web/sasl.cc
@@ -173,7 +173,7 @@ bool authenticate(const char *userid, const char *passwd, const char *service) {
     char pwpath[sizeof(srvaddr.sun_path)];
 
     if (!service) {
-        service = "bios";
+        service = "fty";
     }
 
     strcpy(pwpath, SASLAUTHD_MUX_PATH);


### PR DESCRIPTION
problem: As /etc/pam.d/bios was renamed in fty a while, saslauthd uses a default system pam configuration but not at all fty.  
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>