### PR TITLE
Problem : getting id_asset_element is not optimized

### DIFF
--- a/src/fty-common/web/helpers.cc
+++ b/src/fty-common/web/helpers.cc
@@ -157,9 +157,9 @@ iname_to_dbid (const std::string& url, const std::string& asset_name)
         tntdb::Connection conn = tntdb::connectCached(url);
         tntdb::Statement st = conn.prepareCached(
         " SELECT id_asset_element"
--       " FROM"
--       "   t_bios_asset_element"
--       " WHERE name = :asset_name"
+        " FROM"
+        "   t_bios_asset_element"
+        " WHERE name = :asset_name"
         );
 
         tntdb::Row row = st.set("asset_name", asset_name).selectRow();

--- a/src/fty-common/web/helpers.cc
+++ b/src/fty-common/web/helpers.cc
@@ -155,16 +155,11 @@ iname_to_dbid (const std::string& url, const std::string& asset_name)
         int64_t id = 0;
 
         tntdb::Connection conn = tntdb::connectCached(url);
-        // MVY: This makes sure that passing of asset (display) name will work too
         tntdb::Statement st = conn.prepareCached(
-        " SELECT DISTINCT (asset.id_asset_element) "
-        " FROM "
-        "   t_bios_asset_element AS asset "
-        " LEFT JOIN t_bios_asset_ext_attributes AS ext "
-        " ON "
-        "   asset.id_asset_element = ext.id_asset_element "
-        " WHERE asset.name = :asset_name "
-        " OR (ext.keytag = \"name\" AND ext.value = :asset_name) "
+        " SELECT id_asset_element"
+-       " FROM"
+-       "   t_bios_asset_element"
+-       " WHERE name = :asset_name"
         );
 
         tntdb::Row row = st.set("asset_name", asset_name).selectRow();


### PR DESCRIPTION
Problem :  the exiting request is complex and too long
SELECT DISTINCT (asset.id_asset_element) FROM t_bios_asset_element AS asset  LEFT JOIN t_bios_asset_ext_attributes AS ext ON asset.id_asset_element = ext.id_asset_element  WHERE asset.name = "rack-9" OR (ext.keytag = "name" AND ext.value = "rack-9");
+------------------+
| id_asset_element |
+------------------+
|                9 |
+------------------+
1 row in set (0.09 sec)

Details :
MariaDB [box_utf8]> explain SELECT DISTINCT (asset.id_asset_element) FROM t_bios_asset_element AS asset  LEFT JOIN t_bios_asset_ext_attributes AS ext ON asset.id_asset_element = ext.id_asset_element  WHERE asset.name = "rack-9" OR (ext.keytag = "name" AND ext.value = "rack-9");
+------+-------------+-------+-------+------------------------------+------------------------------+---------+---------------------------------+------+------------------------------+
| id   | select_type | table | type  | possible_keys                | key                          | key_len | ref                             | rows | Extra                        |
+------+-------------+-------+-------+------------------------------+------------------------------+---------+---------------------------------+------+------------------------------+
|    1 | SIMPLE      | asset | index | UI_t_bios_asset_element_NAME | UI_t_bios_asset_element_NAME | 152     | NULL                            |  305 | Using index; Using temporary |
|    1 | SIMPLE      | ext   | ref   | FK_ASSETEXTATTR_ELEMENT_idx  | FK_ASSETEXTATTR_ELEMENT_idx  | 4       | box_utf8.asset.id_asset_element |   43 | Using where; Distinct        |
+------+-------------+-------+-------+------------------------------+------------------------------+---------+---------------------------------+------+------------------------------+
2 rows in set (0.00 sec)

Solution : revert https://github.com/42ity/fty-rest/commit/c803d5252f7401ccd1732ea4dda00c94ccc1b33d
We don't need to support using the friendly user name as parameter. The RFC-11 only describes asset-id.

Result 
MariaDB [box_utf8]> SELECT asset.id_asset_element FROM t_bios_asset_element as asset WHERE asset.name = "rack-9";
+------------------+
| id_asset_element |
+------------------+
|                9 |
+------------------+
1 row in set (0.00 sec)
 explain SELECT asset.id_asset_element FROM t_bios_asset_element as asset WHERE asset.name = "rack-9";
+------+-------------+-------+-------+------------------------------+------------------------------+---------+-------+------+-------------+
| id   | select_type | table | type  | possible_keys                | key                          | key_len | ref   | rows | Extra       |
+------+-------------+-------+-------+------------------------------+------------------------------+---------+-------+------+-------------+
|    1 | SIMPLE      | asset | const | UI_t_bios_asset_element_NAME | UI_t_bios_asset_element_NAME | 152     | const |    1 | Using index |
+------+-------------+-------+-------+------------------------------+------------------------------+---------+-------+------+-------------+
1 row in set (0.00 sec)


Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>