### PR TITLE
Problem: We need TRANSLATE_ME macro to mark translatable strings.

### DIFF
--- a/builds/check_zproject/ci_build.sh
+++ b/builds/check_zproject/ci_build.sh
@@ -6,6 +6,8 @@ set -ex
 [ -n "${REPO_DIR-}" ] || exit 1
 
 # Verify all required dependencies with repos can be checked out
+# Note: certain zproject scripts that deal with deeper dependencies expect that
+# such checkouts are directly in the same parent directory as "this" project.
 cd "$REPO_DIR/.."
 git clone --quiet --depth 1 -b 1.1.2-FTY-master https://github.com/42ity/log4cplus.git log4cplus
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common-logging.git fty-common-logging

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -32,9 +32,14 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     export LANG LC_ALL
 
     if [ -d "./tmp" ]; then
+        # Proto installation area for this project and its deps
         rm -rf ./tmp
     fi
-    mkdir -p tmp
+    if [ -d "./tmp-deps" ]; then
+        # Checkout/unpack and build area for dependencies
+        rm -rf ./tmp-deps
+    fi
+    mkdir -p tmp tmp-deps
     BUILD_PREFIX=$PWD/tmp
 
     PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'`"
@@ -183,8 +188,9 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         echo ""
         BASE_PWD=${PWD}
         echo "`date`: INFO: Building prerequisite 'log4cplus' from Git repository..." >&2
+        cd ./tmp-deps
         $CI_TIME git clone --quiet --depth 1 -b 1.1.2-FTY-master https://github.com/42ity/log4cplus.git log4cplus
-        cd log4cplus
+        cd ./log4cplus
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR
         git --no-pager log --oneline -n1
@@ -215,8 +221,9 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         echo ""
         BASE_PWD=${PWD}
         echo "`date`: INFO: Building prerequisite 'fty-common-logging' from Git repository..." >&2
+        cd ./tmp-deps
         $CI_TIME git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common-logging.git fty-common-logging
-        cd fty-common-logging
+        cd ./fty-common-logging
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR
         git --no-pager log --oneline -n1

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -5,6 +5,7 @@
 nobase_include_HEADERS = \
     fty_common.h \
     fty_common_agents.h \
+    fty_common_macros.h \
     fty_common_library.h
 
 if ENABLE_DRAFTS

--- a/include/fty_common_library.h
+++ b/include/fty_common_library.h
@@ -111,6 +111,7 @@ typedef struct _fty_common_filesystem_t fty_common_filesystem_t;
 
 //  Public classes, each with its own header file
 #include "fty_common_agents.h"
+#include "fty_common_macros.h"
 #ifdef FTY_COMMON_BUILD_DRAFT_API
 #include "fty_common_base.h"
 #include "fty_common_asset_types.h"

--- a/include/fty_common_macros.h
+++ b/include/fty_common_macros.h
@@ -1,0 +1,35 @@
+/*  =========================================================================
+    fty_common_macros - System-wide preprocessor macros
+
+    Copyright (C) 2014 - 2018 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    =========================================================================
+*/
+
+#ifndef FTY_COMMON_MACROS_H_INCLUDED
+#define FTY_COMMON_MACROS_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TRANSLATE_ME(...) __VA_ARGS__
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/project.xml
+++ b/project.xml
@@ -44,5 +44,6 @@
     <class name = "fty_common_str_defs" selftest = "0" />
     <class name = "fty_common_filesystem" selftest = "0" />
     <header name = "fty_common_agents" stable = "1" >Common definitions for agents</header>
+    <header name = "fty_common_macros" stable = "1" >System-wide preprocessor macros</header>
 
 </project>

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -10,7 +10,6 @@ libfty_common.pc
 
 # + config files for mains (if any):
 
-
 # location designated for writing self-tests:
 selftest-rw/
 

--- a/src/fty_common_classes.h
+++ b/src/fty_common_classes.h
@@ -72,7 +72,7 @@ safe_malloc (size_t size, const char *file, unsigned line)
 #else
 #   define zmalloc(size) safe_malloc((size), __FILE__, __LINE__)
 #endif
-#endif
+#endif // __CZMQ_PRELUDE_H_INCLUDED__
 
 
 


### PR DESCRIPTION
Solution: Use variadic macro.

Internet warns that g++ with -pedantic flag may error out in this case, but on our version, it seems to be working.

Signed-off-by: Jana Rapava <janarapava@eaton.com>