### PR TITLE
Problem: using the lib and compiling code with CC, generates a fatal error: "/usr/include/fty_common_utf8.h:25:19: fatal error: cstdint: No such file or directory"

### DIFF
--- a/include/fty_common_utf8.h
+++ b/include/fty_common_utf8.h
@@ -22,8 +22,10 @@
 #ifndef FTY_COMMON_UTF8_H_INCLUDED
 #define FTY_COMMON_UTF8_H_INCLUDED
 
+#ifdef __cplusplus
 #include <cstdint>
 #include <string>
+#endif
 
 //  Self test of this class
 void fty_common_utf8_test (bool verbose);


### PR DESCRIPTION
Solution: #ifdef __cplusplus encapsulation of the two specific C++ includes (in fty_common_utf8.h)
Signed-off-by: Degott, Francois Regis <FrancoisRegisDegott@eaton.com>