### PR TITLE
(M/M) Problem: We need functions to escape params for bash commands.

### DIFF
--- a/include/fty_common_utf8.h
+++ b/include/fty_common_utf8.h
@@ -45,6 +45,9 @@ extern "C" {
 // C wrapper for UTF8::escape
 char* utf8_escape(const char *string);
 
+// C wrapper for UTF8::escape
+char* utf8_bash_escape(const char *string);
+
 // C wrapper for UTF8::jsonify_translation_string
 char *
 utf8_jsonify_translation_string (const char *key, ...);
@@ -77,6 +80,10 @@ jsonify_translation_string (const char *key, ...);
 // Convert translation string + va_list into JSON
 std::string
 vajsonify_translation_string (const char *key, va_list args);
+
+// escape string for use as a bash command parameter
+std::string
+bash_escape (std::string& param);
 
 }
 

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -311,6 +311,26 @@ escape (const std::string& before) {
     return escape (before.c_str ());
 }
 
+std::string
+bash_escape (std::string& param)
+{
+    std::string escape_chars (" \t!\"#$&'()*,;<=>?[\\]^`{|}~");
+    std::string escaped;
+    int start = 0;
+    while (true) {
+        int end = param.find_first_of (escape_chars, start);
+        if (end == std::string::npos) {
+            escaped += param.substr (start);
+            break;
+        }
+        int length = end - start;
+        escaped += param.substr (start, length) + "\\" + param[end];
+        start = end + 1;
+    }
+
+    return escaped;
+}
+
 // This function converts string expressed as ("Text used as a key with %s and %d", var1, var2, ...) into JSON format:
 // {
 //  "key" : "Text used as a key with $var1$ and $var2$",
@@ -486,6 +506,17 @@ char *
 utf8_escape (const char *string)
 {
     std::string escaped_str = UTF8::escape (string);
+    size_t length = escaped_str.length ();
+    char *escaped = (char *) zmalloc (length + 1);
+    strcpy (escaped, escaped_str.c_str ());
+    return escaped;
+}
+
+char *
+utf8_bash_escape (const char *string)
+{
+    std::string string_str (string);
+    std::string escaped_str = UTF8::bash_escape (string_str);
     size_t length = escaped_str.length ();
     char *escaped = (char *) zmalloc (length + 1);
     strcpy (escaped, escaped_str.c_str ());

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -316,14 +316,14 @@ bash_escape (std::string& param)
 {
     std::string escape_chars (" \t!\"#$&'()*,;<=>?[\\]^`{|}~");
     std::string escaped;
-    int start = 0;
+    size_t start = 0;
     while (true) {
-        int end = param.find_first_of (escape_chars, start);
+        size_t end = param.find_first_of (escape_chars, start);
         if (end == std::string::npos) {
             escaped += param.substr (start);
             break;
         }
-        int length = end - start;
+        size_t length = end - start;
         escaped += param.substr (start, length) + "\\" + param[end];
         start = end + 1;
     }


### PR DESCRIPTION
Solution: Add functions which walks the string and add the backslash before every special character.

Signed-off-by: Jana Rapava <janarapava@eaton.com>
 
Unit tests will be added later.