### PR TITLE
Update processing of unknown types and subtypes.

### DIFF
--- a/src/fty_common_asset_types.cc
+++ b/src/fty_common_asset_types.cc
@@ -74,7 +74,7 @@ typeid_to_type (uint16_t type_id)
         case asset_type::DEVICE:
             return "device";
         default:
-            return "unknown";
+            return "N_A";
     }
 }
 
@@ -149,6 +149,9 @@ subtype_to_subtypeid (const std::string &subtype)
     else if(st == "n_a") {
         return asset_subtype::N_A;
     }
+    else if(st == "N_A") {
+        return asset_subtype::N_A;
+    }
     else if(st == "") {
         return asset_subtype::N_A;
     }
@@ -201,7 +204,7 @@ subtypeid_to_subtype (uint16_t subtype_id)
         case asset_subtype::N_A:
             return "N_A";
         default:
-            return "unknown";
+            return "N_A";
     }
 }
 


### PR DESCRIPTION
Asset class assumes N_A instead of unknown, and everything else seems to be comfortable with N_A.

Signed-off-by: Jana Rapava <janarapava@eaton.com>