### PR TITLE
Add missing asset status enum

### DIFF
--- a/include/fty_common_asset_types.h
+++ b/include/fty_common_asset_types.h
@@ -28,6 +28,15 @@
 
 namespace persist {
 
+    enum asset_status {
+        STATUS_UNKNOWN                  = 0,
+
+        STATUS_ACTIVE                   = 1,
+        STATUS_NONACTIVE,
+
+        NB_ASSET_STATUSES
+    };
+
     enum asset_type {
         TUNKNOWN                        = 0,
 
@@ -141,6 +150,12 @@ namespace persist {
 
     asset_operation
     str2operation (const std::string &operation);
+
+    asset_status
+    status_to_statusid (const std::string &status);
+
+    std::string
+    statusid_to_status (asset_status status_id);
 
     uint16_t
     type_to_typeid (const std::string &type);

--- a/src/fty_common_asset_types.cc
+++ b/src/fty_common_asset_types.cc
@@ -42,6 +42,16 @@ namespace persist {
 /**
  * FIXME: THIS IS REDUNDANT WITH THE DATABASE, REPLACE WITH DATABASE QUERIES!
  */
+const static std::array<std::string, NB_ASSET_STATUSES> status_names {
+    "unknown",
+
+    "active",
+    "nonactive"
+};
+
+/**
+ * FIXME: THIS IS REDUNDANT WITH THE DATABASE, REPLACE WITH DATABASE QUERIES!
+ */
 const static std::array<std::string, NB_ASSET_TYPES> type_names {
     "unknown",
 
@@ -157,6 +167,23 @@ bool caseInsensitiveCompare(const std::string& a, const std::string& b)
     std::transform(a.begin(), a.end(), std::back_inserter(la), ::tolower);
     std::transform(b.begin(), b.end(), std::back_inserter(lb), ::tolower);
     return la == lb;
+}
+
+asset_status
+status_to_statusid (const std::string &status)
+{
+    auto r = std::find_if(status_names.begin(), status_names.end(), std::bind(caseInsensitiveCompare, status, std::placeholders::_1));
+    if (r == status_names.end() || *r == "") {
+        return STATUS_UNKNOWN;
+    }
+
+    return static_cast<asset_status>(std::distance(status_names.begin(), r));
+}
+
+std::string
+statusid_to_status (asset_status status_id)
+{
+    return status_names[status_id < status_names.size() ? status_id : STATUS_UNKNOWN];
 }
 
 uint16_t


### PR DESCRIPTION
- Asset statuses are encoded into enum, as for types and subtypes

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>