### PR TITLE
Fix utf8 character manipulations

### DIFF
--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -190,6 +190,9 @@ utf8_octets (const char *c) {
 
 static int
 utf8_compare_octets (const char *s1, const char *s2, size_t pos, size_t length, uint8_t count) {
+    assert (s1);
+    assert (s2);
+
     // FIXME: Should the process really die with invalid UTF strings?
     assert (count >= 1 && count <= 4);
     assert (pos + count <= length);

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -234,8 +234,10 @@ utf8eq (const char *s1, const char *s2) {
         int8_t s1_octets = utf8_octets (s1 + pos);
         int8_t s2_octets = utf8_octets (s2 + pos);
 
-        if (s1_octets == -1 || s2_octets == -1)
+        if (s1_octets == -1 || s2_octets == -1) {
+            log_debug ("Strings '%s' and '%s' are not equal because of invalid UTF-8 sequences", s1, s2);
             return -1;
+        }
 
         // Different octet lengths at position "pos"
         if (s1_octets != s2_octets)

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -179,7 +179,7 @@ utf8_octets (const char *c) {
         if ((*c & 0xF8) == 0xF0) // 1111 0xxx (4 octets)
         return 4;
     else
-        log_error ("Unrecognized utf8 lead byte '%x' in string '%s'", *c, c);
+        log_error ("Unrecognized utf8 lead byte '%" PRIx8 "' in string '%s'", *c, c);
     return -1;
 }
 

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -167,19 +167,20 @@ compare_utf8_codepoint (const char *str_utf8, const char *str_codepoint) {
 int8_t
 utf8_octets (const char *c) {
     assert (c);
-    if ((*c & 0x80) == 0) // lead bit is zero, must be a single ascii
+    uint8_t b = (uint8_t)(*c); // UTF is defined in terms of 8-bit octets, do not equate those to potentially varied-width platform defined char's
+    if ((b & 0x80) == 0) // lead bit is zero, must be a single ascii
         return 1;
     else
-        if ((*c & 0xE0) == 0xC0) // 110x xxxx (2 octets)
+        if ((b & 0xE0) == 0xC0) // 110x xxxx (2 octets)
         return 2;
     else
-        if ((*c & 0xF0) == 0xE0) // 1110 xxxx (3 octets)
+        if ((b & 0xF0) == 0xE0) // 1110 xxxx (3 octets)
         return 3;
     else
-        if ((*c & 0xF8) == 0xF0) // 1111 0xxx (4 octets)
+        if ((b & 0xF8) == 0xF0) // 1111 0xxx (4 octets)
         return 4;
     else
-        log_error ("Unrecognized utf8 lead byte '%" PRIx8 "' in string '%s'", *c, c);
+        log_error ("Unrecognized utf8 lead byte '%" PRIx8 "' in string '%s'", b, c);
     return -1;
 }
 

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -189,7 +189,7 @@ utf8_octets (const char *c) {
 // 1 - different
 
 static int
-utf8_compare_octets (const char *s1, const char *s2, size_t pos, size_t length, uint8_t count) {
+utf8_compare_octets (const char *s1, const char *s2, size_t pos, size_t length, int8_t count) {
     assert (s1);
     assert (s2);
 
@@ -200,7 +200,7 @@ utf8_compare_octets (const char *s1, const char *s2, size_t pos, size_t length, 
     // FIXME: When assert is a no-op (production) should this proceed with errors then ignored above?
     // e.g. a count==-1 would yield "return 0" below, and so perceived-equal utf8 chars...
 
-    for (int i = 0; i < count; i++) {
+    for (int8_t i = 0; i < count; i++) {
         const char c1 = s1[pos + i];
         const char c2 = s2[pos + i];
 

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -167,7 +167,7 @@ compare_utf8_codepoint (const char *str_utf8, const char *str_codepoint) {
 int8_t
 utf8_octets (const char *c) {
     assert (c);
-    uint8_t b = (uint8_t)(*c); // UTF is defined in terms of 8-bit octets, do not equate those to potentially varied-width platform defined char's
+    const uint8_t b = (uint8_t)(*c); // UTF is defined in terms of 8-bit octets, do not equate those to potentially varied-width platform defined char's
     if ((b & 0x80) == 0) // lead bit is zero, must be a single ascii
         return 1;
     else

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -282,6 +282,11 @@ escape (const char *string) {
     while (i < length) {
         char c = string[i];
         int8_t width = UTF8::utf8_octets (string + i);
+        if (width == -1) {
+            log_debug ("Cannot escape string '%s' because of invalid UTF-8 sequences at offset %ju", string, (uintmax_t)i);
+            return "(invalid_utf8)";
+        }
+
         if (c == '"') {
             after.append ("\\\"");
         }
@@ -319,6 +324,8 @@ escape (const char *string) {
         else {
             after += c;
         }
+
+        // We should not have width==0 ever, and -1 is filtered above
         i += width;
     }
     return after;

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -233,8 +233,8 @@ utf8eq (const char *s1, const char *s2) {
 
 
     while (pos < length) {
-        uint8_t s1_octets = utf8_octets (s1 + pos);
-        uint8_t s2_octets = utf8_octets (s2 + pos);
+        int8_t s1_octets = utf8_octets (s1 + pos);
+        int8_t s2_octets = utf8_octets (s2 + pos);
 
         if (s1_octets == -1 || s2_octets == -1)
             return -1;

--- a/src/fty_common_utf8.cc
+++ b/src/fty_common_utf8.cc
@@ -225,13 +225,11 @@ utf8eq (const char *s1, const char *s2) {
     assert (s1);
     assert (s2);
 
-    if (strlen (s1) != strlen (s2))
+    size_t length = strlen (s1);
+    if (length != strlen (s2))
         return 0;
 
     size_t pos = 0;
-    size_t length = strlen (s1);
-
-
     while (pos < length) {
         int8_t s1_octets = utf8_octets (s1 + pos);
         int8_t s2_octets = utf8_octets (s2 + pos);


### PR DESCRIPTION
Pulling a loose string in the world...

While pursuing a log message from failed test, leading to invalid sequence here, I found that I lacked information about which codepath got the failing string, and also that code (in some tntnet servlet) looped at this intensively. Looking into this codebase I found that we did not actually catch error cases thanks to int/uint mismatch, which would explain the looping.

The reason I put you all in CC is that we have a number of `assert()` clauses in these routines that seem doubly dangerous to me, assuming:
* if they manage to see invalid inputs in test runs (of debug builds) I suppose they would just crash the program using this library and not let it handle/log/... bad inputs intelligently
* if we have bad inputs in production code, asserts are a no-op and we cheerfully use the NULL pointers, error codes as sizes, etc.

Also notably we have nearly identical (but older per `git blame`) code in https://github.com/42ity/fty-alert-engine/blob/master/src/rule.cc#L23 which I suppose we can collapse with use of one implementation from fty-common. That code differs slightly in accepted arguments (`std::string` vs `char *`, and different interpretation of pos/offsets) but otherwise the logic and bugs are equivalent ;)