### PR TITLE
Return always types without space

### DIFF
--- a/src/fty_common_asset_types.cc
+++ b/src/fty_common_asset_types.cc
@@ -174,9 +174,6 @@ subtypeid_to_subtype (uint16_t subtype_id)
 {
     try {
         std::string subtype = subtype_names.at(subtype_id);
-        for (auto& it : subtype_equivs)
-            if (subtype == it.second)
-                { if (!it.first.empty()) return it.first; break; }
         return subtype;
     }
     catch (...) {}

--- a/src/fty_common_base.cc
+++ b/src/fty_common_base.cc
@@ -218,9 +218,9 @@ fty_common_base_test (bool verbose)
                 std::transform(attempt.begin(), attempt.end(), attempt.begin(), ::tolower);
 
             // handle exceptions
-            if (type == "") attempt = "N_A";
-            else if (type == "rackcontroller") attempt = "rack controller";
-            else if (type == "patchpanel") attempt = "patch panel";
+            if (type == "") attempt = fty::SUB_N_A;
+            else if (type == "rack controller") attempt = fty::SUB_RACK_CONTROLLER;
+            else if (type == "patch panel") attempt = fty::SUB_PATCH_PANEL;
 
             bool ok = (attempt == s);
             if (!ok) printf("ERROR: subtype: %s, id: %d, s: %s, attempt: %s\n", type.c_str(), id, s.c_str(), attempt.c_str());


### PR DESCRIPTION
UI needs to use "rack controller" and "patch panel" without space.