### PR TITLE
Add missing virtual destructor to SyncServer class

### DIFF
--- a/include/fty_common_sync_server.h
+++ b/include/fty_common_sync_server.h
@@ -43,6 +43,7 @@ namespace fty
     class SyncServer
     {
     public:
+        virtual ~SyncServer() = default;
         virtual Payload handleRequest(const Sender & sender, const Payload & payload) = 0;
     };
 


### PR DESCRIPTION
Fix build warnings in other modules

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>